### PR TITLE
Zeit no longer works installing global packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,15 @@ RUN echo "CONFIG_ID=$CONFIG_ID"
 RUN npm install
 RUN npm run build
 
-RUN apk del git
 RUN rm -rf node_modules
 RUN rm -rf src
 RUN rm -rf docs
 RUN rm -rf public
-RUN npm install -g serve
+RUN rm package.json
+RUN npm install serve
+RUN apk del git
 
 EXPOSE 3000:3000
 
 # Serve the prod build from the dist folder
-CMD ["npm", "run", "serve"]
+CMD ["./node_modules/.bin/serve", "-s", "dist", "-p", "3000"]


### PR DESCRIPTION
Zeit/now no longer works installing global packages, so the serve package is installed as local package.