### PR TITLE
Feature/iota links

### DIFF
--- a/src/components/organisms/Markdown/index.js
+++ b/src/components/organisms/Markdown/index.js
@@ -493,7 +493,15 @@ class Markdown extends PureComponent {
 
     aLink(props) {
         const localProps = { ...props };
-        if (localProps.href.startsWith('http') || localProps.href.startsWith('iota')) {
+        if (localProps.href.startsWith('javascript:void(0)')) {
+            if (localProps.children && localProps.children.length > 0) {
+                if (localProps.children[0].props && localProps.children[0].props.value) {
+                    localProps.href = localProps.children[0].props.value;
+                    localProps.target = '_blank';
+                    localProps.rel = 'noopener noreferrer';
+                }
+            }
+        } else if (localProps.href.startsWith('http') || localProps.href.startsWith('iota')) {
             localProps.target = '_blank';
             localProps.rel = 'noopener noreferrer';
         } else {

--- a/src/components/organisms/Markdown/index.js
+++ b/src/components/organisms/Markdown/index.js
@@ -493,7 +493,7 @@ class Markdown extends PureComponent {
 
     aLink(props) {
         const localProps = { ...props };
-        if (localProps.href.startsWith('http')) {
+        if (localProps.href.startsWith('http') || localProps.href.startsWith('iota')) {
             localProps.target = '_blank';
             localProps.rel = 'noopener noreferrer';
         } else {


### PR DESCRIPTION
Alllow links to start with iota://

e.g.

```
[iota://XNGPUCURQLLJFGXNDCMROGYNWAZP9AFWSVEUAIWIESOSPYDUPWSPSREEBWJPD9ZWZPAJKBHPLG99DJWJCZUHWTQTDD/?amount=1000000&message=shirt](iota://XNGPUCURQLLJFGXNDCMROGYNWAZP9AFWSVEUAIWIESOSPYDUPWSPSREEBWJPD9ZWZPAJKBHPLG99DJWJCZUHWTQTDD/?amount=1000000&message=shirt)
```

Allow bare markdown link format

e.g 

```
<https://www.iota.org>
```


In combination to simplify links that have the same text and link

```
<iota://XNGPUCURQLLJFGXNDCMROGYNWAZP9AFWSVEUAIWIESOSPYDUPWSPSREEBWJPD9ZWZPAJKBHPLG99DJWJCZUHWTQTDD/?amount=1000000&message=shirt>
```