### PR TITLE
Fix sanitization of anchor links

### DIFF
--- a/src/components/organisms/Markdown/index.js
+++ b/src/components/organisms/Markdown/index.js
@@ -557,7 +557,7 @@ class Markdown extends PureComponent {
                 const anchorParts = localProps.href.split('#');
                 localProps.href = sanitizeHashId(anchorParts[0], true).replace(/.md$/i, '');
                 if (anchorParts.length === 2) {
-                    localProps.href += `#${sanitizeHashId(anchorParts[1])}`;
+                    localProps.href += `#${sanitizeHashId(anchorParts[1], false, true)}`;
                 }
             }
         }
@@ -671,7 +671,7 @@ class Markdown extends PureComponent {
     }
 
     heading(props) {
-        let id = sanitizeHashId(this.stripSearchQuery(props.children.map(a => a.props.value).join('')));
+        let id = sanitizeHashId(this.stripSearchQuery(props.children.map(a => a.props.value).join('')), false, true);
         if (this.headingCounters[id] === undefined) {
             this.headingCounters[id] = -1;
         }

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -1,4 +1,4 @@
-export function sanitizeHashId(id, skipLowerCase) {
+export function sanitizeHashId(id, skipLowerCase, isForAnchor) {
     // make lower case
     // de-escape spaces
     // replace spaces with hyphens
@@ -8,11 +8,13 @@ export function sanitizeHashId(id, skipLowerCase) {
     if (!skipLowerCase) {
         id = id.toLowerCase();
     }
+    if (isForAnchor) {
+        id = id.replace(/\./g, '');
+    }
     return id
         .replace(/\\ /g, ' ')
         .replace(/\?/g, '')
         .replace(/'/g, '')
-        .replace(/\./g, '')
         .replace(/ /g, '-');
 }
 

--- a/src/utils/projects.js
+++ b/src/utils/projects.js
@@ -38,7 +38,7 @@ export function createPageTableOfContents(projectUrlParts, projects) {
         if (currentIndex && currentIndex.toc) {
             toc = toc.concat(currentIndex.toc
                 .filter(item => item.level > 1)
-                .map(item => ({ name: item.name, link: `#${sanitizeHashId(item.name)}`, level: item.level })));
+                .map(item => ({ name: item.name, link: `#${sanitizeHashId(item.name, false, true)}`, level: item.level })));
         }
     }
 


### PR DESCRIPTION
Fixed, previous sanitization of links always removed dots, it now only applies to the anchor part of links.