### PR TITLE
Add extra level of navigation

### DIFF
--- a/src/components/molecules/SideMenu/index.js
+++ b/src/components/molecules/SideMenu/index.js
@@ -119,18 +119,41 @@ class SideMenu extends React.Component {
                                                 <div className="side-menu-item__header">{menuListItem.name}</div>
                                                 <ul>
                                                     {menuListItem.items.map((subItem, idx) => (
-                                                        <li key={idx}
-                                                            className={classNames(
+                                                        <React.Fragment key={idx}>
+                                                            <li className={classNames(
                                                                 'side-menu-item',
                                                                 { 'side-menu-item--active': subItem.selected }
                                                             )}>
-                                                            <Link
-                                                                href={subItem.link}
-                                                                target={subItem.link.startsWith('http') ? '_blank' : undefined}
-                                                                className={classNames({ 'side-menu-item--active': subItem.selected })}>
-                                                                {subItem.name}
-                                                            </Link>
-                                                        </li>
+                                                                {subItem.type === 'section-header-item' && (
+                                                                    <Link
+                                                                        href={subItem.link}
+                                                                        target={subItem.link.startsWith('http') ? '_blank' : undefined}
+                                                                        className={classNames({ 'side-menu-item--active': subItem.selected })}>
+                                                                        {subItem.name}
+                                                                    </Link>
+                                                                )}
+                                                                {subItem.type === 'section-header-sub' && (
+                                                                    <React.Fragment>
+                                                                        <Link href={subItem.items[0].link} target={subItem.items[0].link.startsWith('http') ? '_blank' : undefined}>{subItem.name}</Link>
+                                                                        {subItem.selected && (
+                                                                            <ul className="side-menu-item-sub">
+                                                                                {subItem.items.map((child, idx3) => (
+                                                                                    <li key={idx3}
+                                                                                        className={
+                                                                                            classNames(
+                                                                                                'side-menu-item-sub-child',
+                                                                                                { 'side-menu-item-sub-child--active': child.selected }
+                                                                                            )
+                                                                                        }
+                                                                                    >
+                                                                                        <Link href={child.link} target={child.link.startsWith('http') ? '_blank' : undefined}>{child.name}</Link>
+                                                                                    </li>
+                                                                                ))}
+                                                                            </ul>
+                                                                        )}
+                                                                    </React.Fragment>
+                                                                )}                                                            </li>
+                                                        </React.Fragment>
                                                     ))}
                                                 </ul>
                                             </div>

--- a/src/components/molecules/TreeMenu/index.js
+++ b/src/components/molecules/TreeMenu/index.js
@@ -53,15 +53,41 @@ class TreeMenu extends React.Component {
                                 )
                             }>
                                 {section.items.map((item, idx2) => (
-                                    <li
-                                        key={idx2}
-                                        className={
-                                            classNames(
-                                                'tree-menu__section-item',
-                                                { 'tree-menu__section-item--selected': item.selected }
-                                            )
-                                        }
-                                    ><Link href={item.link} target={item.link.startsWith('http') ? '_blank' : undefined}>{item.name}</Link></li>
+                                    <React.Fragment key={idx2}>
+                                        <li
+                                            className={
+                                                classNames(
+                                                    'tree-menu__section-item',
+                                                    { 'tree-menu__section-item--selected': item.selected }
+                                                )
+                                            }
+                                        >
+                                            {item.type === 'section-header-item' && (
+                                                <Link href={item.link} target={item.link.startsWith('http') ? '_blank' : undefined}>{item.name}</Link>
+                                            )}
+                                            {item.type === 'section-header-sub' && (
+                                                <React.Fragment>
+                                                    <Link href={item.items[0].link} target={item.items[0].link.startsWith('http') ? '_blank' : undefined}>{item.name}</Link>
+                                                    {item.selected && (
+                                                        <ul className="tree-menu__section-item-sub">
+                                                            {item.items.map((child, idx3) => (
+                                                                <li key={idx3}
+                                                                    className={
+                                                                        classNames(
+                                                                            'tree-menu__section-item-sub-child',
+                                                                            { 'tree-menu__section-item-sub-child--selected': child.selected }
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    <Link href={child.link} target={child.link.startsWith('http') ? '_blank' : undefined}>{child.name}</Link>
+                                                                </li>
+                                                            ))}
+                                                        </ul>
+                                                    )}
+                                                </React.Fragment>
+                                            )}
+                                        </li>
+                                    </React.Fragment>
                                 ))}
                             </ul>
                         </React.Fragment>

--- a/src/utils/projects.js
+++ b/src/utils/projects.js
@@ -104,6 +104,7 @@ export function createSideMenuEntries(projects, projectFullURL) {
 export function buildItemTree(projectVersionPages, projectFullURL) {
     const tree = [];
     let inSection;
+    let inSectionSub;
 
     for (let i = 0; i < projectVersionPages.length; i++) {
         const nameParts = projectVersionPages[i].name.split('/');
@@ -115,6 +116,7 @@ export function buildItemTree(projectVersionPages, projectFullURL) {
                 selected: projectVersionPages[i].link === projectFullURL
             });
             inSection = undefined;
+            inSectionSub = undefined;
         } else {
             const currentSection = inSection ? inSection.name : '';
             if (nameParts[0] !== currentSection) {
@@ -125,14 +127,38 @@ export function buildItemTree(projectVersionPages, projectFullURL) {
                     expanded: false
                 };
                 tree.push(inSection);
+                inSectionSub = undefined;
             }
-            inSection.items.push({
-                name: nameParts.slice(1).join('/'),
-                link: projectVersionPages[i].link,
-                selected: projectVersionPages[i].link === projectFullURL
-            });
             if (projectVersionPages[i].link === projectFullURL) {
                 inSection.selected = true;
+            }
+
+            if (nameParts.length === 2) {
+                inSection.items.push({
+                    type: 'section-header-item',
+                    name: nameParts.slice(1).join('/'),
+                    link: projectVersionPages[i].link,
+                    selected: projectVersionPages[i].link === projectFullURL
+                });
+            } else {
+                const currentSectionSub = inSectionSub ? inSectionSub.name : '';
+                if (nameParts[1] !== currentSectionSub) {
+                    inSectionSub = {
+                        type: 'section-header-sub',
+                        name: nameParts[1],
+                        items: [],
+                        expanded: false
+                    };
+                    inSection.items.push(inSectionSub);
+                }
+                if (projectVersionPages[i].link === projectFullURL) {
+                    inSectionSub.selected = true;
+                }
+                inSectionSub.items.push({
+                    name: nameParts.slice(2).join('/'),
+                    link: projectVersionPages[i].link,
+                    selected: projectVersionPages[i].link === projectFullURL
+                });
             }
         }
     }
@@ -237,7 +263,7 @@ export const getNextPage = (projectUrlParts, projects) => {
         }
 
         // Skip any that don't have home page content
-        while(!projects[projectIndex].home) {
+        while (!projects[projectIndex].home) {
             projectIndex++;
             if (projectIndex === projects.length) {
                 projectIndex = 0;
@@ -274,7 +300,7 @@ export const getPreviousPage = (projectUrlParts, projects) => {
         }
 
         // Skip any that don't have home page content
-        while(!projects[projectIndex].home) {
+        while (!projects[projectIndex].home) {
             projectIndex--;
             if (projectIndex < 0) {
                 projectIndex = projects.length - 1;


### PR DESCRIPTION
Left hand navigation now allows for an extra level of depth. Implemented using extra `/` in the `doc-index` files.

e.g.

```
[Introduction/Overview](/introduction/overview.md)
[Concepts/The ledger](/concepts/the-ledger.md)
[Concepts/Foo/Neighbor IRI node](/concepts/neighbor-iri-node.md)
[Concepts/Foo/Transaction validation](/concepts/transaction-validation.md)
[Concepts/Zero message queue](/concepts/zero-message-queue.md)
[Concepts/Local snapshot](/concepts/local-snapshot.md)
```

Produces

![image](https://user-images.githubusercontent.com/5030334/61037985-d6951700-a3d4-11e9-8312-4df473590180.png)

Also applies to burger menu

![image](https://user-images.githubusercontent.com/5030334/61038091-12c87780-a3d5-11e9-8bd3-30517f4c6d79.png)
