### PR TITLE
Fix markdown markup examples not showing

### DIFF
--- a/buildProjects.js
+++ b/buildProjects.js
@@ -235,6 +235,7 @@ async function extractTocAndValidateAssets(docsFolder, projectFolder, version, d
             // ## Blah blah
             // But not inside our tab controls or project topics
 
+            doc = removeMarkdownCode(doc);
             doc = removeTabControls(doc);
             doc = removeProjectTopics(doc);
 
@@ -316,6 +317,20 @@ function removeTabControls(markdown) {
 function removeProjectTopics(markdown) {
     const re = /#### (.*)\n(\[.*\]\((.*)\))?([\S\s]*?)---/gm;
     return markdown.replace(re, '');
+}
+
+function removeMarkdownCode(markdown) {
+    const re = /^```markdown[\S\s]*?```/gm;
+
+    let match;
+    do {
+        match = re.exec(markdown);
+        if (match) {
+            markdown = markdown.replace(match[0], '');
+        }
+    } while (match);
+
+    return markdown;
 }
 
 async function assetHtmlImage(markdown, docPath, assets) {

--- a/src/components/organisms/Markdown/index.js
+++ b/src/components/organisms/Markdown/index.js
@@ -102,6 +102,11 @@ class Markdown extends PureComponent {
         // Strip the h1 from the start of the content
         content = content.trim().replace(/(^# .*)/, '').trim();
 
+        const markdownMatches = this.findMarkdownContainers(content);
+        for (let i = 0; i < markdownMatches.length; i++) {
+            content = content.replace(markdownMatches[i], `<markdown index="${i}"></markdown>`);
+        }
+
         const tabMatches = this.findTabContainers(content);
         for (let i = 0; i < tabMatches.length; i++) {
             this.tabContainers.push(this.findTabs(tabMatches[i]));
@@ -135,6 +140,10 @@ class Markdown extends PureComponent {
         }
 
         content = this.replaceSearchQuery(content);
+
+        for (let i = 0; i < markdownMatches.length; i++) {
+            content = content.replace(`<markdown index="${i}"></markdown>`, markdownMatches[i]);
+        }
 
         this.setState({
             content
@@ -170,6 +179,21 @@ class Markdown extends PureComponent {
         }
 
         return content;
+    }
+
+    findMarkdownContainers(content) {
+        const matches = [];
+        const re = /^```markdown([\S\s]*?)```$/gm;
+
+        let match;
+        do {
+            match = re.exec(content);
+            if (match && match.length === 2) {
+                matches.push(match[0]);
+            }
+        } while (match);
+
+        return matches;
     }
 
     findTabContainers(content) {
@@ -473,7 +497,7 @@ class Markdown extends PureComponent {
                     alt: match[2] || ''
                 });
             }
-        }
+        } 
 
         // Do default html processing
         // https://github.com/rexxars/react-markdown/blob/b6caaba0437b00132d58337913e66a7d1bfb30ce/src/renderers.js#L100-L113


### PR DESCRIPTION
Fix allow the parser to show the examples of markdown markup in the contribution page, before the parser tried implementing the examples.

Also the projects build script is updated so that headers in markdown examples are not included in TOCs.