### PR TITLE
feat/add-project-overview

### DIFF
--- a/src/components/organisms/Overview/index.js
+++ b/src/components/organisms/Overview/index.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import { createProjectLinks, parseProjectUrl } from '../../../utils/projects';
+import ProjectsPropTypes from '../../../utils/projectsPropTypes';
+import Heading from '../../atoms/Heading';
+
+class Overview extends React.Component {
+    static propTypes = {
+        projects: ProjectsPropTypes.isRequired,
+    };
+
+    constructor(props) {
+        super(props);
+
+
+        const real_projects = [
+            {
+                name: "Access",
+                link: "/docs/iota-access/1.0/overview",
+                description: ""
+            },
+            {
+                name: "Identity",
+                link: "http://identity.docs.iots.org/",
+                description: ""
+            },
+            {
+                name: "Stronghold",
+                link: "http://stronghold.docs.iota.org/",
+                description: ""
+            },
+            {
+                name: "Client",
+                link: "https://client-lib.docs.iota.org",
+                description: ""
+            },
+            {
+                name: "Wallet",
+                link: "https://wallet-lib.docs.iota.org",
+                description: ""
+            },
+            {
+                name: "Smart Contracts",
+                link: "https://iscp.docs.iota.org",
+                description: ""
+            },
+            {
+                name: "Streams",
+                link: "/docs/iota-streams/1.0/overview",
+                description: ""
+            },
+            {
+                name: "HORNET",
+                link: "https://gohornet.github.io/hornet",
+                description: ""
+            },
+            {
+                name: "Bee",
+                link: "https://bee.docs.iota.org",
+                description: ""
+            },
+            {
+                name: "goShimmer",
+                link: "https://goshimmer.docs.iota.org",
+                description: ""
+            },
+
+        ];
+        
+        const projectLinks = createProjectLinks(this.props.projects);
+        console.log("projectLinks", projectLinks)
+
+        let dynamicSections = [{
+            heading: 'Developer Docs',
+            links: projectLinks
+        }];
+
+        this.state = {
+            realProjects: real_projects,
+            projectLinks: createProjectLinks(this.props.projects)
+        };
+
+        this.handleClick = this.handleClick.bind(this);
+    }
+
+    handleClick(urlOrProjectFolder) {
+        if (urlOrProjectFolder.startsWith('http')) {
+            window.open(urlOrProjectFolder, '_blank');
+        } else {
+            this.props.history.push(this.state.projectLinks.find(pl => pl.folder === urlOrProjectFolder).link);
+        }
+        this.setState({ currentProject: urlOrProjectFolder });
+    }
+
+    render() {
+        return (
+            <div className="overview">
+                <h2 className="heading project_heading">Overview</h2>
+                <div className="overview__wrapper">
+                {
+                    this.state.realProjects.map((c, idx) =>
+                        <div className="overview__item">
+                            <a href={c.link} target="_blank">{ c.name }</a>
+                        </div>
+                    )
+                }
+            </div>
+            </div>
+        );
+    }
+}
+
+export default Overview;

--- a/src/components/organisms/Overview/index.js
+++ b/src/components/organisms/Overview/index.js
@@ -20,7 +20,7 @@ class Overview extends React.Component {
             },
             {
                 name: "Identity",
-                link: "http://identity.docs.iots.org/",
+                link: "http://identity.docs.iota.org/",
                 description: ""
             },
             {
@@ -94,7 +94,7 @@ class Overview extends React.Component {
     render() {
         return (
             <div className="overview">
-                <h2 className="heading project_heading">Overview</h2>
+                <h2 className="heading project_heading">Quicklinks</h2>
                 <div className="overview__wrapper">
                 {
                     this.state.realProjects.map((c, idx) =>

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -12,6 +12,7 @@ import CardContainer from '../components/molecules/HomePageCard';
 import ProjectTopicsContainer from '../components/molecules/ProjectTopicsContainer';
 import SideMenu from '../components/molecules/SideMenu';
 import Header from '../components/organisms/Header';
+import Overview from '../components/organisms/Overview';
 import { submitFeedback } from '../utils/api';
 import HomeDataPropTypes from '../utils/homeDataPropTypes';
 import { localStorageSet } from '../utils/localStorage';
@@ -78,6 +79,11 @@ class Home extends React.Component {
                     projects={this.props.projects}
                     onCloseClick={this.handleBurgerClick}
                     highlightedItem={this.state.projectFullURL} />
+                <div className="layouts--1-column">
+                    <Overview 
+                        projects={this.props.projects}
+                />
+                </div>
                 <div id='image-background' style={{ background: '#f3f2f1', width: '100%', height: '0px', position: 'absolute' }} />
                 <div className="layouts--2-column">
                     <div className="left-column">

--- a/src/style.css
+++ b/src/style.css
@@ -2,3 +2,28 @@
   min-height: 100vh;
 }
 
+.overview {
+  color: #000;
+}
+.overview__wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  padding-left: 100px;
+  padding-right: 100px;
+}
+.overview__item {
+  flex: 1 0 21%;
+  max-width: 25%;
+  width: auto;
+  padding: 20px 16px;
+  border-radius: 0.5rem;
+  display: flex;
+  align-content: center;
+  -webkit-box-align: center;
+  align-items: center;
+  text-decoration: none;
+  font-size: 0.875rem;
+  color: rgb(72, 87, 118);
+  font-weight: bold;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
add overview component with project links and some custom styling

Inspired by the Menu of http://chrysalis.iota.org and [Cloudflare Docs](https://developers.cloudflare.com/docs)


## TODO
- [ ]  Visual Update
- [ ] Add icons (optional)
- [ ] Component Refactor
- [ ] Style.css refactor

## Preview
![Bildschirmfoto 2021-03-05 um 16 46 00](https://user-images.githubusercontent.com/10562055/110138434-45a55780-7dd2-11eb-9f2d-810a9d6fd197.png)
